### PR TITLE
BGP negotiated timers. Display BGP timers in CLI.

### DIFF
--- a/vtysh/bgp_vty.c
+++ b/vtysh/bgp_vty.c
@@ -9723,9 +9723,11 @@ DEFUN(show_ipv6_bgp,
 
 static void
 show_one_bgp_neighbor(struct vty *vty, char *name,
-                      const struct ovsrec_bgp_neighbor *ovs_bgp_neighbor)
+    const struct ovsrec_bgp_neighbor *ovs_bgp_neighbor,
+    const struct ovsrec_bgp_router *ovs_bgp_router)
 {
     int i = 0;
+    int64_t value_timers[2];
 
     if (object_is_peer_group(ovs_bgp_neighbor))
         return;
@@ -9810,9 +9812,37 @@ show_one_bgp_neighbor(struct vty *vty, char *name,
                                    ovs_bgp_neighbor->maximum_prefix_limit));
 
     if (ovs_bgp_neighbor->n_tcp_port_number)
-        vty_out(vty, "    tcp_port_number: %s\n\n",
+        vty_out(vty, "    tcp_port_number: %s\n",
                 safe_print_integer(ovs_bgp_neighbor->n_tcp_port_number,
                                    ovs_bgp_neighbor->tcp_port_number));
+
+    /*
+     * Print configured BGP timers, priority is
+     * Peer-group timers > Per-neighbor configured >
+     * > Per-router configured > default values
+    */
+    if (ovs_bgp_neighbor->bgp_peer_group && ovs_bgp_neighbor->bgp_peer_group->n_timers) {
+        memcpy(value_timers, ovs_bgp_neighbor->bgp_peer_group->value_timers, sizeof(value_timers));
+    }
+    else if (ovs_bgp_neighbor->n_timers) {
+        memcpy(value_timers, ovs_bgp_neighbor->value_timers, sizeof(value_timers));
+    }
+    else if (ovs_bgp_router->n_timers) {
+        memcpy(value_timers, ovs_bgp_router->value_timers, sizeof(value_timers));
+    }
+    else {
+        value_timers[0] = BGP_DEFAULT_HOLDTIME;
+        value_timers[1] = BGP_DEFAULT_KEEPALIVE;
+    }
+
+    vty_out(vty, "    Configured timers: Keepalive %ld, Holdtime %ld\n",
+        value_timers[1], value_timers[0]);
+
+    if (ovs_bgp_neighbor->n_negotiated_timers) {
+        vty_out(vty, "    Negotiated timers: Keepalive %ld, Holdtime %ld\n\n",
+                ovs_bgp_neighbor->value_negotiated_timers[1],
+                ovs_bgp_neighbor->value_negotiated_timers[0]);
+    }
 
     if (ovs_bgp_neighbor->n_statistics) {
         vty_out(vty, "    statistics:\n");
@@ -9847,7 +9877,8 @@ show_bgp_router_neighbors(struct vty *vty,
            (peer && (0 == strcmp(ovs_bgp_router->key_bgp_neighbors[i],
                                  peer)))) {
             show_one_bgp_neighbor(vty, ovs_bgp_router->key_bgp_neighbors[i],
-                                  ovs_bgp_router->value_bgp_neighbors[i]);
+                                  ovs_bgp_router->value_bgp_neighbors[i],
+                                  ovs_bgp_router);
         }
     }
 }

--- a/vtysh/bgp_vty.c
+++ b/vtysh/bgp_vty.c
@@ -9838,7 +9838,7 @@ show_one_bgp_neighbor(struct vty *vty, char *name,
     vty_out(vty, "    Configured timers: Keepalive %ld, Holdtime %ld\n",
         value_timers[1], value_timers[0]);
 
-    if (ovs_bgp_neighbor->n_negotiated_timers) {
+    if (ovs_bgp_neighbor->n_negotiated_timers == 2) {
         vty_out(vty, "    Negotiated timers: Keepalive %ld, Holdtime %ld\n\n",
                 ovs_bgp_neighbor->value_negotiated_timers[1],
                 ovs_bgp_neighbor->value_negotiated_timers[0]);

--- a/vtysh/bgp_vty.h
+++ b/vtysh/bgp_vty.h
@@ -34,6 +34,8 @@
 #define NETWORK_MAX_LEN 49
 #define TIMER_KEY_MAX_LENGTH 80
 #define BGP_MAX_TIMERS 2
+#define BGP_DEFAULT_HOLDTIME 180
+#define BGP_DEFAULT_KEEPALIVE 60
 
 /*
 ** depending on the outcome of the db transaction, returns

--- a/vtysh/vtysh_ovsdb_if.c
+++ b/vtysh/vtysh_ovsdb_if.c
@@ -174,6 +174,7 @@ bgp_ovsdb_init()
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_passive);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_password);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_timers);
+    ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_negotiated_timers);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_route_maps);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_prefix_lists);
     ovsdb_idl_add_column(idl, &ovsrec_bgp_neighbor_col_aspath_filters);


### PR DESCRIPTION
Tags: fix, dev, Github issue #9

Change-Id: I275a2a889faf719ed37fbc0e53e6952efeac42cc
Signed-off-by: Ilya Schepin ischepin@mera.ru

CLI command `show ip bgp neighbors` will now show per-neighbor (or per-peer-group) configured BGP timers (keepalive and holdtime) and per-neighbor negotiated timers.  
New status field `negotiated_timers` was added to OVSDB table BGP_Neighbor  
Priority of timer parameters as follows:  
Per-peer-group configured > per-neighbor configured > per-router configured > default values  
Depends on MERAprojects/ops-quagga#24 and MERAprojects/ops#3
