### PR TITLE
MERAprojects/ops-build#8 IPv6 static routes aren't configured

### DIFF
--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -903,4 +903,26 @@ inet6_ntoa (struct in6_addr addr)
   inet_ntop (AF_INET6, &addr, buf, INET6_ADDRSTRLEN);
   return buf;
 }
+
+int
+ip_addr_is_equal (const char *addr_str1, const char *addr_str2) {
+  int af;
+
+  af = ((strstr(addr_str1, ":") != NULL) ? AF_INET6 : AF_INET);
+  return ip_addr_is_equal_af(af, addr_str1, addr_str2);
+}
+
+int
+ip_addr_is_equal_af (int af, const char *addr_str1, const char *addr_str2) {
+  struct in6_addr addr1, addr2;
+
+  if (af == AF_INET) {
+    return !strcmp(addr_str1, addr_str2);
+  }
+  else if (inet_pton(AF_INET6, addr_str1, &addr1) && inet_pton(AF_INET6, addr_str2, &addr2)) {
+    return !IPV6_ADDR_CMP(&addr1, &addr2);
+  }
+  return 0;
+}
+
 #endif /* HAVE_IPV6 */

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -219,6 +219,8 @@ extern void masklen2ip6 (const int, struct in6_addr *);
 
 extern void str2in6_addr (const char *, struct in6_addr *);
 extern const char *inet6_ntoa (struct in6_addr);
+extern int ip_addr_is_equal (const char *, const char *);
+extern int ip_addr_is_equal_af (int, const char *, const char *);
 
 #endif /* HAVE_IPV6 */
 


### PR DESCRIPTION
Update some files for vtysh in ops-cli part according
to changes in ops-quagga part.

SHA-1 Full notation IPv6 addresses in ops-quagga:
a6015478b7ba3e4ec64cddd3195a4f4b14086ec3

SHA-1 Merge branch 'meraswitch/devel/full_notation_ipv6_addr'
into meraswitch/devel/master in ops-quagga:
21243b35010c209ddb1e3dd8a1786425d600ff04

Change-Id: I99986996ae319f5ad81808535bf82a4bd14f9fec