### PR TITLE
Issue #24: Not possible to create peer-group with name longer than 80…

### DIFF
--- a/vtysh/bgp_vty.c
+++ b/vtysh/bgp_vty.c
@@ -3168,6 +3168,12 @@ DEFUN(neighbor_peer_group,
       "Neighbor tag\n"
       "Configure peer-group\n")
 {
+    if (strlen(argv[0]) > 80){
+        vty_out(vty, "\n%%Peer group name should be less"
+                     " or equal to 80 characters\n");
+        return CMD_WARNING;
+    }
+
     return cli_neighbor_peer_group_cmd_execute(NULL, argv[0]);
 }
 

--- a/vtysh/bgp_vty.c
+++ b/vtysh/bgp_vty.c
@@ -2670,7 +2670,8 @@ bgp_neighbor_peer_group_insert_to_bgp_router(const struct ovsrec_bgp_router *
     int i = 0;
 
     bgp_neighbor_peer_name_list =
-        xmalloc(80 * (bgp_router_context->n_bgp_neighbors + 1));
+        xmalloc(BGP_PEER_GROUP_MAX_LENGTH *
+               (bgp_router_context->n_bgp_neighbors + 1));
     bgp_neighbor_peer_group_list =
         xmalloc(sizeof *bgp_router_context->value_bgp_neighbors *
                               (bgp_router_context->n_bgp_neighbors + 1));
@@ -2935,7 +2936,8 @@ bgp_neighbor_remove_for_matching_peer_group_from_bgp_router(
     int i, j;
 
     bgp_neighbor_peer_name_list =
-        xmalloc(80 * (bgp_router_context->n_bgp_neighbors - 1));
+        xmalloc(BGP_PEER_GROUP_MAX_LENGTH *
+               (bgp_router_context->n_bgp_neighbors - 1));
     bgp_neighbor_peer_group_list =
         xmalloc(sizeof * bgp_router_context->value_bgp_neighbors *
                 (bgp_router_context->n_bgp_neighbors - 1));
@@ -2970,7 +2972,8 @@ bgp_neighbor_peer_group_remove_from_bgp_router(const struct ovsrec_bgp_router *
     int i = 0, j = 0;
 
     bgp_neighbor_peer_name_list =
-        xmalloc(80 * (bgp_router_context->n_bgp_neighbors - 1));
+        xmalloc(BGP_PEER_GROUP_MAX_LENGTH *
+               (bgp_router_context->n_bgp_neighbors - 1));
     bgp_neighbor_peer_group_list =
         xmalloc(sizeof * bgp_router_context->value_bgp_neighbors *
                 (bgp_router_context->n_bgp_neighbors - 1));
@@ -3168,7 +3171,7 @@ DEFUN(neighbor_peer_group,
       "Neighbor tag\n"
       "Configure peer-group\n")
 {
-    if (strlen(argv[0]) > 80){
+    if (strlen(argv[0]) > BGP_PEER_GROUP_MAX_LENGTH){
         vty_out(vty, "\n%%Peer group name should be less"
                      " or equal to 80 characters\n");
         return CMD_WARNING;

--- a/vtysh/bgp_vty.c
+++ b/vtysh/bgp_vty.c
@@ -2670,7 +2670,7 @@ bgp_neighbor_peer_group_insert_to_bgp_router(const struct ovsrec_bgp_router *
     int i = 0;
 
     bgp_neighbor_peer_name_list =
-        xmalloc(BGP_PEER_GROUP_MAX_LENGTH *
+        xmalloc(BGP_PEER_GROUP_NAME_MAX_LENGTH *
                (bgp_router_context->n_bgp_neighbors + 1));
     bgp_neighbor_peer_group_list =
         xmalloc(sizeof *bgp_router_context->value_bgp_neighbors *
@@ -2936,7 +2936,7 @@ bgp_neighbor_remove_for_matching_peer_group_from_bgp_router(
     int i, j;
 
     bgp_neighbor_peer_name_list =
-        xmalloc(BGP_PEER_GROUP_MAX_LENGTH *
+        xmalloc(BGP_PEER_GROUP_NAME_MAX_LENGTH *
                (bgp_router_context->n_bgp_neighbors - 1));
     bgp_neighbor_peer_group_list =
         xmalloc(sizeof * bgp_router_context->value_bgp_neighbors *
@@ -2972,7 +2972,7 @@ bgp_neighbor_peer_group_remove_from_bgp_router(const struct ovsrec_bgp_router *
     int i = 0, j = 0;
 
     bgp_neighbor_peer_name_list =
-        xmalloc(BGP_PEER_GROUP_MAX_LENGTH *
+        xmalloc(BGP_PEER_GROUP_NAME_MAX_LENGTH *
                (bgp_router_context->n_bgp_neighbors - 1));
     bgp_neighbor_peer_group_list =
         xmalloc(sizeof * bgp_router_context->value_bgp_neighbors *
@@ -3171,7 +3171,7 @@ DEFUN(neighbor_peer_group,
       "Neighbor tag\n"
       "Configure peer-group\n")
 {
-    if (strlen(argv[0]) > BGP_PEER_GROUP_MAX_LENGTH){
+    if (strlen(argv[0]) > BGP_PEER_GROUP_NAME_MAX_LENGTH){
         vty_out(vty, "\n%%Peer group name should be less"
                      " or equal to 80 characters\n");
         return CMD_WARNING;

--- a/vtysh/bgp_vty.h
+++ b/vtysh/bgp_vty.h
@@ -36,7 +36,7 @@
 #define BGP_MAX_TIMERS 2
 #define BGP_DEFAULT_HOLDTIME 180
 #define BGP_DEFAULT_KEEPALIVE 60
-#define BGP_PEER_GROUP_MAX_LENGTH 80
+#define BGP_PEER_GROUP_NAME_MAX_LENGTH 80
 
 /*
 ** depending on the outcome of the db transaction, returns

--- a/vtysh/bgp_vty.h
+++ b/vtysh/bgp_vty.h
@@ -36,6 +36,7 @@
 #define BGP_MAX_TIMERS 2
 #define BGP_DEFAULT_HOLDTIME 180
 #define BGP_DEFAULT_KEEPALIVE 60
+#define BGP_PEER_GROUP_MAX_LENGTH 80
 
 /*
 ** depending on the outcome of the db transaction, returns


### PR DESCRIPTION
… char

Added validation so that any peer group name that is longer
than 80 characters is rejected and the warning message is shown.

Change-Id: Id05bdcc457e5a2e536ef2eead1f8b8a009eee9ad